### PR TITLE
feat(standalone): install latest patch of minor version

### DIFF
--- a/static/install-opentofu.sh
+++ b/static/install-opentofu.sh
@@ -747,6 +747,15 @@ install_standalone() {
     fi
   fi
 
+  if expr "${OPENTOFU_VERSION}" : '\d\+\.\d\+$' > /dev/null 2>&1; then
+    log_info "Determining latest OpenTofu ${OPENTOFU_VERSION} patch version..."
+    OPENTOFU_VERSION=$(download_file "https://api.github.com/repos/opentofu/opentofu/releases" - | grep "tag_name.*${OPENTOFU_VERSION}\.\d\+\"," | head -1 | sed -e 's/.*tag_name":"v//' -e 's/.*tag_name": "v//' -e 's/".*//')
+    if [ -z "${OPENTOFU_VERSION}" ]; then
+      log_error "Failed to obtain the latest release from the GitHub API. Try passing --opentofu-version to specify a version."
+      return "${TOFU_INSTALL_EXIT_CODE_INSTALL_FAILED}"
+    fi
+  fi
+
   OS="$(uname | tr '[:upper:]' '[:lower:]')"
   ARCH="$(uname -m | sed -e 's/aarch64/arm64/' -e 's/x86_64/amd64/')"
   if [ -z "${OS}" ]; then


### PR DESCRIPTION
With the coming deprecation of the OCI container image as a base image, I think it's useful for OCI container images maintainers to be able to pick only the minor version to use `exp: 1.6, 1.7, 1.8, etc...`.

This will make maintainers focus automating on their OCI container images lifecycle instead of manually update the OpenTofu version with each patch.

I am not sure if supporting the same thing based on the major version can be useful or not, unless the OpenTofu jumps up to v2, `v1.*.* == latest`

This should solves #30 too