### PR TITLE
Generate /tofu/series.json metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/opentofu/get.opentofu.org
 
-go 1.21
+go 1.24
+
+require github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=

--- a/releases-generator/api.go
+++ b/releases-generator/api.go
@@ -39,10 +39,15 @@ func (g *generator) Generate() (map[string][]byte, error) {
 		return nil, fmt.Errorf("failed to fetch GitHub releases: %w", err)
 	}
 	index := githubResponseToIndex(releases)
+	seriesIndex := githubResponseToSeriesSummary(releases)
 
 	result["api.json"], err = json.Marshal(index)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal releases API file: %w", err)
+	}
+	result["series.json"], err = json.MarshalIndent(seriesIndex, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal release series API file: %w", err)
 	}
 
 	result["index.html"], err = renderTemplate(indexTemplate, index)

--- a/releases-generator/api_test.go
+++ b/releases-generator/api_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
 
 	releases_generator "github.com/opentofu/get.opentofu.org/releases-generator"
 	"github.com/opentofu/get.opentofu.org/releases-generator/github"
@@ -90,4 +93,178 @@ func TestGenerator_Generate(t *testing.T) {
 			t.Fatal("Expected file link not found.")
 		}
 	})
+}
+
+func TestGenerator_Generate_seriesJSON(t *testing.T) {
+	releases := github.ReleasesResponse{
+		{
+			TagName:     "v1.13.0-alpha1", // ignored because we don't consider alpha-only series as really existing yet
+			PublishedAt: mustParseRFC3339("2099-03-01T00:00:00Z"),
+		},
+		{
+			TagName:     "v1.12.0-beta1",
+			PublishedAt: mustParseRFC3339("2099-02-01T00:00:00Z"),
+		},
+		{
+			TagName:     "v1.12.0-beta2",
+			PublishedAt: mustParseRFC3339("2099-02-02T00:00:00Z"),
+		},
+		{
+			TagName:     "v1.11.0-rc1",
+			PublishedAt: mustParseRFC3339("2099-01-01T00:00:00Z"),
+		},
+		{
+			// This is intentionally out of order to make sure our
+			// implementation is not depending on the order returned by GitHub,
+			// so we are resilient to oddities that might be caused by
+			// republishing.
+			TagName:     "v1.10.0-rc1",
+			PublishedAt: mustParseRFC3339("2025-06-04T13:21:40Z"),
+		},
+		{
+			TagName:     "v1.10.3",
+			PublishedAt: mustParseRFC3339("2025-07-05T17:44:31Z"),
+			IsDraft:     true, // should be completely ignored
+		},
+		{
+			TagName:     "v1.10.2",
+			PublishedAt: mustParseRFC3339("2025-07-01T17:44:31Z"),
+		},
+		{
+			TagName:     "v1.10.1",
+			PublishedAt: mustParseRFC3339("2025-06-25T15:48:03Z"),
+		},
+		{
+			TagName:     "v1.10.0",
+			PublishedAt: mustParseRFC3339("2025-06-24T13:58:50Z"),
+		},
+		{
+			TagName:     "v1.10.0-beta1",
+			PublishedAt: mustParseRFC3339("2025-05-19T15:57:41Z"),
+		},
+		{
+			TagName:     "v1.10.0-alpha1",
+			PublishedAt: mustParseRFC3339("2025-03-28T13:42:48Z"),
+		},
+		{
+			// We don't currently have any process that causes prereleases
+			// of patch releases but this is here just to make sure this
+			// program handles that in a reasonable way: it should essentially
+			// ignore this and continue treating v1.9.1 as an active series.
+			TagName:     "v1.9.2-beta1",
+			PublishedAt: mustParseRFC3339("2025-04-25T00:00:00Z"),
+		},
+		{
+			TagName:     "v1.9.1",
+			PublishedAt: mustParseRFC3339("2025-04-24T20:54:41Z"),
+		},
+		{
+			TagName:     "v1.8.9",
+			PublishedAt: mustParseRFC3339("2025-04-24T20:53:48Z"),
+		},
+		{
+			TagName:     "v1.7.8",
+			PublishedAt: mustParseRFC3339("2025-04-24T20:53:05Z"),
+		},
+		{
+			TagName:     "v1.6.0",
+			PublishedAt: mustParseRFC3339("2024-08-07T13:53:04Z"),
+		},
+		{
+			// We should be resilient against release names that don't follow
+			// our typical naming scheme. We have no plans to do this
+			// intentionally, but we want to keep working if we do it
+			// accidentally. This should be completely ignored.
+			TagName:     "garbage",
+			PublishedAt: mustParseRFC3339("2029-01-01T00:00:00Z"),
+		},
+	}
+
+	gh, err := github.NewFake(releases)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	generator, err := releases_generator.New(gh)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := generator.Generate()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raw, ok := result["series.json"]
+	if !ok {
+		t.Fatal("series.json not found")
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string]any{
+		"series": []any{
+			map[string]any{
+				"id":          "1.10",
+				"latest":      map[string]any{"id": "1.10.2", "published_at": "2025-07-01T17:44:31Z"},
+				"released_at": "2025-06-24T13:58:50Z", // the time of the earliest non-prerelease, 1.10.0
+				"status":      "active",
+			},
+			map[string]any{
+				"id":          "1.9",
+				"latest":      map[string]any{"id": "1.9.1", "published_at": "2025-04-24T20:54:41Z"},
+				"released_at": "2025-04-24T20:54:41Z",
+				"status":      "active",
+			},
+			map[string]any{
+				"id":          "1.8",
+				"latest":      map[string]any{"id": "1.8.9", "published_at": "2025-04-24T20:53:48Z"},
+				"released_at": "2025-04-24T20:53:48Z",
+				"status":      "active",
+			},
+			// Prerelease-only series always appear after active series even
+			// though they have higher numbers and may have newer release dates.
+			map[string]any{
+				"id":          "1.11",
+				"latest":      map[string]any{"id": "1.11.0-rc1", "published_at": "2099-01-01T00:00:00Z"},
+				"released_at": "2099-01-01T00:00:00Z",
+				"status":      "rc",
+			},
+			map[string]any{
+				// (Having both an rc and beta series at the same time would be
+				// weird but we support it anyway just in case.)
+				"id":          "1.12",
+				"latest":      map[string]any{"id": "1.12.0-beta2", "published_at": "2099-02-02T00:00:00Z"},
+				"released_at": "2099-02-02T00:00:00Z", // for prerelease series this always matches the latest prerelease time
+				"status":      "beta",
+			},
+			// End-of-life series always appear at the very end.
+			map[string]any{
+				"id":          "1.7",
+				"latest":      map[string]any{"id": "1.7.8", "published_at": "2025-04-24T20:53:05Z"},
+				"released_at": "2025-04-24T20:53:05Z",
+				"status":      "eol",
+			},
+			map[string]any{
+				"id":          "1.6",
+				"latest":      map[string]any{"id": "1.6.0", "published_at": "2024-08-07T13:53:04Z"},
+				"released_at": "2024-08-07T13:53:04Z",
+				"status":      "eol",
+			},
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Error("wrong result\n" + diff)
+	}
+}
+
+func mustParseRFC3339(s string) time.Time {
+	ret, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return ret
 }

--- a/releases-generator/data.go
+++ b/releases-generator/data.go
@@ -1,7 +1,10 @@
 package releases_generator
 
 import (
+	"cmp"
+	"slices"
 	"strings"
+	"time"
 
 	"github.com/opentofu/get.opentofu.org/releases-generator/github"
 )
@@ -22,10 +25,16 @@ func githubResponseToIndex(response github.ReleasesResponse) *Index {
 		return &Index{Versions: nil}
 	}
 	result := &Index{
-		Versions: make([]Version, len(response)),
+		Versions: make([]Version, 0, len(response)),
 	}
-	for i, release := range response {
-		result.Versions[i] = Version{
+	for _, release := range response {
+		if release.IsDraft {
+			// We request the releases without an authenticated token so we
+			// should not actually get any drafts, but we'll check anyway to
+			// make sure this doesn't get broken under future maintenence.
+			continue
+		}
+		result.Versions = append(result.Versions, Version{
 			ID: strings.TrimLeft(release.TagName, "v"),
 			Files: func() []string {
 				files := make([]string, len(release.Assets))
@@ -34,7 +43,237 @@ func githubResponseToIndex(response github.ReleasesResponse) *Index {
 				}
 				return files
 			}(),
-		}
+		})
 	}
 	return result
+}
+
+type SeriesIndex struct {
+	Series []Series `json:"series"`
+}
+
+// Series describes a minor release series, such as "1.10", as an overview
+// derived from the individual releases in that series.
+type Series struct {
+	// ID is a string representation of the whole-series version prefix, like "1.10".
+	ID string `json:"id"`
+
+	// LatestVersion is a string representation of the latest available version
+	// in this series.
+	//
+	// For a series whose status is [StatusActive] this is guaranteed not to
+	// be a prerelease, even if there is a prerelease of higher precedence
+	// than the latest non-prerelease.
+	LatestVersion VersionMeta `json:"latest"`
+
+	// Status summarizes the current overall status of this series.
+	//
+	// [SeriesActive] represents a series that is still "supported" in the
+	// sense of our release support policy.
+	Status SeriesStatus `json:"status"`
+
+	// ReleasedAt is the publication time of the first non-prerelease version in
+	// the series, or the latest prerelease version if there are not yet any
+	// non-prerelease versions.
+	ReleasedAt time.Time `json:"released_at,omitempty"`
+}
+
+type VersionMeta struct {
+	ID          string    `json:"id"`
+	PublishedAt time.Time `json:"published_at"`
+}
+
+func githubResponseToSeriesSummary(response github.ReleasesResponse) *SeriesIndex {
+	ret := &SeriesIndex{Series: nil}
+	if len(response) == 0 {
+		return ret
+	}
+
+	bySeries := make(map[string][]*github.Release)
+	for i := range response {
+		release := &response[i] // reference rather than copy
+		if release.IsDraft {
+			continue
+		}
+		seriesID := seriesIDForReleaseTagName(release.TagName)
+		if seriesID == "" {
+			// Tag does not match the shape we expect for a normal release,
+			// so we'll ignore it for series-summarization purposes.
+			continue
+		}
+		bySeries[seriesID] = append(bySeries[seriesID], release)
+	}
+
+	ret.Series = make([]Series, 0, len(bySeries))
+	for seriesID, releases := range bySeries {
+		ret.Series = append(ret.Series, Series{
+			ID: seriesID,
+		})
+		series := &ret.Series[len(ret.Series)-1]
+
+		// To make the rest of this a little easier we'll sort the releases
+		// in each series so that the oldest appears first. As long as we
+		// keep numbering our releases in a sensible way this should mean
+		// that prereleases will appear before their respective release
+		// and lower-numbered releases appear before higher-numbered ones.
+		slices.SortFunc(releases, func(a, b *github.Release) int {
+			return a.PublishedAt.Compare(b.PublishedAt)
+		})
+
+		for _, release := range releases {
+			releaseStatus := seriesStatusForReleaseTagName(release.TagName)
+			if releaseStatus == SeriesInvalid {
+				continue
+			}
+			if series.Status == SeriesInvalid {
+				// The first release we find in each series initializes
+				// series object, so we can update it as needed on subsequent
+				// iterations of this loop.
+				series.Status = releaseStatus
+				series.ReleasedAt = release.PublishedAt
+				series.LatestVersion = VersionMeta{
+					ID:          strings.TrimLeft(release.TagName, "v"),
+					PublishedAt: release.PublishedAt,
+				}
+				continue
+			}
+			oldStatus := series.Status
+			if series.Status < releaseStatus {
+				series.Status = releaseStatus
+			}
+			switch series.Status {
+			case SeriesActive:
+				// For an active series, the earliest active release decides
+				// the "released at" time.
+				if oldStatus != SeriesActive || release.PublishedAt.Compare(series.ReleasedAt) < 0 {
+					series.ReleasedAt = release.PublishedAt
+				}
+			default:
+				// For non-active (i.e. prerelease) series, the most recent
+				// prerelease decides the "released at" time. If we get here
+				// with series.Status != SeriesActive then we definitely
+				// haven't seen an active release yet.
+				if release.PublishedAt.Compare(series.ReleasedAt) > 0 {
+					series.ReleasedAt = release.PublishedAt
+				}
+			}
+			if releaseStatus == series.Status && series.LatestVersion.PublishedAt.Compare(release.PublishedAt) < 0 {
+				series.LatestVersion = VersionMeta{
+					ID:          strings.TrimLeft(release.TagName, "v"),
+					PublishedAt: release.PublishedAt,
+				}
+			}
+		}
+	}
+	ret.Series = slices.DeleteFunc(ret.Series, func(s Series) bool {
+		return s.Status == SeriesInvalid
+	})
+	slices.SortFunc(ret.Series, func(a, b Series) int {
+		// On our first pass we order by release date, newest first, so that
+		// we can easily find the most recent three releases below.
+		if a.Status != b.Status {
+			return cmp.Compare(b.Status, a.Status)
+		}
+		// Within each status, the newest "ReleasedAt" time appears first.
+		return b.ReleasedAt.Compare(a.ReleasedAt)
+	})
+	// TODO: One day the list of series will become large and at that point
+	// we might choose to limit the number of "eol"-status items we return,
+	// but for now we'll just keep all of them.
+
+	// Only the three most recent "active" releases are actually active, per
+	// our release support policy. We'll mark all of the earlier ones as
+	// being end-of-life.
+	// We have considered guaranteeing a minimum amount of time for a release
+	// to be supported despite the three-series limit and if we adopt that
+	// in future we'll need to incorporate that into the following, but for
+	// now we're assuming that we start new series infrequently enough that
+	// a minimium time guarantee is not needed.
+	foundActive := 0
+	for i := range ret.Series {
+		series := &ret.Series[i] // reference rather than copy
+		if series.Status == SeriesActive {
+			foundActive++
+			if foundActive > 3 {
+				series.Status = SeriesEndOfLife
+			}
+		}
+	}
+	// With the statuses now finalized, we'll group the releases by
+	// status so that the active ones always appear first. This uses
+	// a stable sort to preserve the publication date ordering we
+	// applied above within each status group.
+	slices.SortStableFunc(ret.Series, func(a, b Series) int {
+		return cmp.Compare(b.Status, a.Status)
+	})
+
+	return ret
+}
+
+func seriesIDForReleaseTagName(tagName string) string {
+	// We expect a tag name like "v1.10.0", possibly followed by a prerelease
+	// suffix like "-beta1". Other forms produce unspecified results.
+	v := strings.TrimLeft(tagName, "v")
+	if len(v) == len(tagName) {
+		// There was no "v" prefix, so invalid
+		return ""
+	}
+	if strings.Count(v, ".") != 2 {
+		// Wrong number of dots, so invalid.
+		return ""
+	}
+	// Everything up to the last dot is the series identifier: "1.10.0-beta1"
+	// belongs to "1.10".
+	return v[:strings.LastIndexByte(v, '.')]
+}
+
+func seriesStatusForReleaseTagName(tagName string) SeriesStatus {
+	_, pre, _ := strings.Cut(tagName, "-")
+	if pre == "" {
+		return SeriesActive
+	}
+	if strings.HasPrefix(pre, "rc") {
+		return SeriesRC
+	}
+	if strings.HasPrefix(pre, "beta") {
+		return SeriesBeta
+	}
+	// No other suffixes are recognized
+	// Note that we intentionally disregard "alpha" because those happen via
+	// a separate process before the release branch has been established:
+	// a series that _only_ has alpha releases doesn't really exist yet.
+	return SeriesInvalid
+}
+
+// SeriesStatus represents the overall status of a [Series], based on whether
+// there are any
+type SeriesStatus int
+
+// The following constants are ordered so that we can take the highest value
+// that applies across all individual releases in a series by numeric comparison.
+const (
+	SeriesInvalid SeriesStatus = iota
+	SeriesEndOfLife
+	SeriesBeta
+	SeriesRC
+	SeriesActive
+)
+
+func (s SeriesStatus) MarshalJSON() ([]byte, error) {
+	switch s {
+	case SeriesActive:
+		return []byte(`"active"`), nil
+	case SeriesBeta:
+		return []byte(`"beta"`), nil
+	case SeriesRC:
+		return []byte(`"rc"`), nil
+	case SeriesEndOfLife:
+		return []byte(`"eol"`), nil
+	case SeriesInvalid:
+		// Should not actually try to return series with this status
+		return []byte(`null`), nil
+	default:
+		// The cases above should be exhaustive for all [SeriesStatus] constants.
+		panic("unsupported SeriesStatus value")
+	}
 }

--- a/releases-generator/github/github.go
+++ b/releases-generator/github/github.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 )
 
 // ReleasesResponse contains all releases fetched from GitHub.
@@ -13,8 +14,10 @@ type ReleasesResponse []Release
 
 // Release describes a single release on GitHub.
 type Release struct {
-	TagName string  `json:"tag_name"`
-	Assets  []Asset `json:"assets"`
+	TagName     string    `json:"tag_name"`
+	PublishedAt time.Time `json:"published_at"`
+	IsDraft     bool      `json:"draft"`
+	Assets      []Asset   `json:"assets"`
 }
 
 // Asset describes a single asset.


### PR DESCRIPTION
This new metadata file, which would appear at `https://get.opentofu.org/tofu/series.json`, summarizes our minor release series rather than describing all of the individual release versions separately as in `api.json`.

```json
{
  "series": [
    {
      "id": "1.10",
      "latest": {
        "id": "1.10.2",
        "published_at": "2025-07-01T17:44:31Z"
      },
      "status": "active",
      "released_at": "2025-06-24T13:58:50Z"
    },
    {
      "id": "1.9",
      "latest": {
        "id": "1.9.1",
        "published_at": "2025-04-24T20:54:41Z"
      },
      "status": "active",
      "released_at": "2024-12-30T12:22:57Z"
    },
    {
      "id": "1.8",
      "latest": {
        "id": "1.8.9",
        "published_at": "2025-04-24T20:53:48Z"
      },
      "status": "active",
      "released_at": "2024-07-23T14:20:18Z"
    },
    {
      "id": "1.7",
      "latest": {
        "id": "1.7.8",
        "published_at": "2025-04-24T20:53:05Z"
      },
      "status": "eol",
      "released_at": "2024-04-24T13:31:17Z"
    },
    {
      "id": "1.6",
      "latest": {
        "id": "1.6.3",
        "published_at": "2024-07-09T14:11:30Z"
      },
      "status": "eol",
      "released_at": "2023-12-19T14:46:44Z"
    }
  ]
}
```

This is mainly for our own use to drive other automated processes that need to work on a per-series basis, like our automated scanning for upstream security vulnerabilities in the main opentofu repository, but it might also be useful for others who want to easily track the latest release in a particular series, or know when the series they are using has become end-of-life, or similar.

I wrote this as a prototype for part of the RFC discussed in https://github.com/opentofu/opentofu/pull/2868, and specifically for the [Avoiding Commits in Other Repositories](https://github.com/opentofu/opentofu/blob/rfc-release-automation/rfc/20250527-automated-release-process.md#avoiding-commits-in-other-repositories) part. This will remain a draft for now since we've not yet discussed that RFC at all.
