### PR TITLE
Add dnf support to yum-based installer

### DIFF
--- a/static/install-opentofu.sh
+++ b/static/install-opentofu.sh
@@ -621,7 +621,7 @@ EOF
       return "${TOFU_INSTALL_EXIT_CODE_INSTALL_FAILED}"
     fi
   done
-  if ! as_root ${YUM_COMMAND} install -y tofu; then
+  if ! as_root "${YUM_COMMAND}" install -y tofu; then
     log_error "Failed to install tofu via ${YUM_COMMAND}."
     return "${TOFU_INSTALL_EXIT_CODE_INSTALL_FAILED}"
   fi

--- a/static/install-opentofu.sh
+++ b/static/install-opentofu.sh
@@ -563,13 +563,17 @@ EOF
   return "${TOFU_INSTALL_EXIT_CODE_OK}"
 }
 
-# This function installs OpenTofu via the yum command line utility. It returns $TOFU_INSTALL_EXIT_CODE_INSTALL_REQUIREMENTS_NOT_MET
-# if yum is not available.
+# This function installs OpenTofu via the dnf or yum command line utility. It returns $TOFU_INSTALL_EXIT_CODE_INSTALL_REQUIREMENTS_NOT_MET
+# if neither dnf nor yum is available.
 install_yum() {
-  if ! command_exists "yum"; then
+  if command_exists "dnf"; then
+    YUM_COMMAND="dnf"
+  elif command_exists "yum"; then
+    YUM_COMMAND="yum"
+  else
     return "${TOFU_INSTALL_EXIT_CODE_INSTALL_REQUIREMENTS_NOT_MET}"
   fi
-  log_info "Installing OpenTofu using yum..."
+  log_info "Installing OpenTofu using ${YUM_COMMAND}..."
   if [ "${SKIP_VERIFY}" -ne "1" ]; then
     GPGCHECK=1
     FINAL_GPG_URL="${RPM_GPG_URL}"
@@ -617,8 +621,8 @@ EOF
       return "${TOFU_INSTALL_EXIT_CODE_INSTALL_FAILED}"
     fi
   done
-  if ! as_root yum install -y tofu; then
-    log_error "Failed to install tofu via yum."
+  if ! as_root ${YUM_COMMAND} install -y tofu; then
+    log_error "Failed to install tofu via ${YUM_COMMAND}."
     return "${TOFU_INSTALL_EXIT_CODE_INSTALL_FAILED}"
   fi
   if ! tofu --version; then


### PR DESCRIPTION
Fixes opentofu/opentofu#1205

The installer script only checked for yum, which fails on systems like Fedora 22+ and RHEL/AlmaLinux 8+ where yum is deprecated and only dnf is available. This change makes the script prefer dnf when available, falling back to yum for older systems.

Testing

Used the existing test suite against two distros to cover both code paths:

Fedora (dnf-only) — confirms dnf path works:
The dnf command is available.
Installing OpenTofu using dnf...
Running command as root: dnf install -y tofu
...
Complete!
OpenTofu v1.11.5
on linux_arm64

Rocky Linux (yum available) — confirms yum fallback still works: Installing OpenTofu using yum...
...
Complete!
OpenTofu v1.12.0
on linux_arm64

Tests run with:
bash
DISTRO=fedora METHOD=repo SH=bash ./tests/linux/test.sh DISTRO=rocky METHOD=repo SH=bash ./tests/linux/test.sh